### PR TITLE
start at a timeOffset so that all arc indicators rotate in sync

### DIFF
--- a/SpinKit/Animations/RTSpinKitArcAnimation.m
+++ b/SpinKit/Animations/RTSpinKitArcAnimation.m
@@ -61,6 +61,7 @@
     anim.repeatCount = HUGE_VALF;
     anim.duration = 0.8;
     anim.beginTime = beginTime;
+    anim.timeOffset = [[NSDate date] timeIntervalSince1970];
     anim.keyTimes = @[@(0.0), @(0.5), @(1.0)];
 
     anim.values = @[


### PR DESCRIPTION
This makes a huge difference visually when there are multiple activity indicators on screen at the same time, or if you need to switch views and create/destroy activity indicators.